### PR TITLE
FIX: #1 Add 'dotnet add package' command to include FoodService.Nugget.Models

### DIFF
--- a/.github/workflows/FoodServiceApi20240506113327.yml
+++ b/.github/workflows/FoodServiceApi20240506113327.yml
@@ -19,7 +19,9 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
     - name: Restore
-      run: dotnet restore "${{ env.WORKING_DIRECTORY }}"
+      run: |
+        dotnet restore "${{ env.WORKING_DIRECTORY }}"
+        dotnet add "${{ env.WORKING_DIRECTORY }}" package FoodService.Nugget.Models
     - name: Build
       run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
     - name: Test


### PR DESCRIPTION
Add 'dotnet add package' command to include FoodService.Nugget.Models 

This commit updates the YAML workflow file to include the 'dotnet add package FoodService.Nugget.Models' command right after the 'dotnet restore' command. This ensures that the 'FoodService.Nugget.Models' package is installed in the project before compilation, testing, and publishing, thus resolving the error of not finding the package during restoration.