### PR TITLE
FIX🐛: #1 Added GitHub Packages as a package source in the build pipeline

### DIFF
--- a/.github/workflows/FoodServiceApi20240506113327.yml
+++ b/.github/workflows/FoodServiceApi20240506113327.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Restore
       run: |
         dotnet restore "${{ env.WORKING_DIRECTORY }}"
-        dotnet add "${{ env.WORKING_DIRECTORY }}" package FoodService.Nugget.Models --version ${{ env.FOOD_SERVICE_MODELS_VERSION }}
+        dotnet restore "${{ env.WORKING_DIRECTORY }}" --source "https://nuget.pkg.github.com/Org-FoodService/index.json"
     - name: Build
       run: dotnet build "${{ env.WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
     - name: Test


### PR DESCRIPTION
 Added GitHub Packages as a package source in the build pipeline

In this commit, I included an additional 'dotnet restore' command with the '--source' flag to specify GitHub Packages as the package source. This ensures that the required package 'FoodService.Nugget.Models' can be found and restored from GitHub Packages during the build process. This change resolves the issue of package restoration failure due to the package not being found in the default sources. Tested and verified the build pipeline successfully restores the required packages from GitHub Packages.